### PR TITLE
Resolve the cache file local to the current directory, not the directory of cache.js

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -42,7 +42,7 @@ function isCacheValid (cache, fileHash, query) {
 function loadIconsFromDiskCache (loader, query, cacheFile, fileHash, callback) {
   // Stop if cache is disabled
   if (!query.persistentCache) return callback(null);
-  var resolvedCacheFile = path.resolve(__dirname, loader._compiler.parentCompilation.compiler.outputPath, cacheFile);
+  var resolvedCacheFile = path.resolve(loader._compiler.parentCompilation.compiler.outputPath, cacheFile);
 
   fs.exists(resolvedCacheFile, function (exists) {
     if (!exists) return callback(null);


### PR DESCRIPTION
While running `favicons-webpack-plugin` on my system, I noticed that the icons were being rebuilt on every webpack run, even though I had configured `persistCache: true`. (I opened [this issue](https://github.com/jantimon/favicons-webpack-plugin/issues/26) to address it.)

To investigate, I poked around `cache.js`. I noticed that `resolvedCacheFile` was being set to a path equivalent to this:

    D:\projects\my_project_name\node_modules\favicons-webpack-plugin\lib\dist\my_prefix_path\.cache

In `emitCacheInformationFile`, the value of `cacheFile` was just a relative path (equivalent to `my_path_prefix_path\.cache`), and so it was being saved to:

    D:\projects\my_project_name\dist\my_prefix_path\.cache

Thus, the cache file was being saved to the location I expected, but it was being read from a path within `node_modules\favicons-webpack-plugin`. Since the file didn't exist there, it couldn't read the cache info, and thus regenerated the files every time.

This makes sense given the code. `path.resolve(__dirname` meant that the cache file location was set relative to `cache.js` inside `node_modules\favicons-webpack-plugin`.

Removing the `__dirname` resolves the input path back to the expected path within my project, and thus reactivates the cache detection; files now only generate if there's a hash change, which is what I expect.

I'm running on Windows via Git Bash, if that makes a difference.

Unfortunately, I couldn't verify this fix using the tests. Before my change, when I run `npm tests` on my fork, I get this output:

https://gist.github.com/softcraft-development/b9c0459e65cbf6c8ee415757e562a377

I get the same output after I apply the change as well.