### PR TITLE
Pass all possible configuration options to Favicon

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,4 +1,5 @@
 'use strict';
+var _ = require('lodash');
 var path = require('path');
 var SingleEntryPlugin = require('webpack/lib/SingleEntryPlugin');
 
@@ -17,13 +18,9 @@ module.exports.compileTemplate = function compileTemplate (options, context, com
   childCompiler.context = context;
   childCompiler.apply(
     new SingleEntryPlugin(context, '!!' + require.resolve('./favicons.js') + '?' +
-      JSON.stringify({
-        outputFilePrefix: options.prefix,
-        icons: options.icons,
-        background: options.background,
-        persistentCache: options.persistentCache,
-        appName: options.title
-      }) + '!' + options.logo)
+      JSON.stringify(_.extend({
+        outputFilePrefix: options.prefix
+      }, options)) + '!' + options.logo)
   );
 
   // Fix for "Uncaught TypeError: __webpack_require__(...) is not a function"

--- a/lib/favicons.js
+++ b/lib/favicons.js
@@ -47,11 +47,21 @@ function getPublicPath (compilation) {
 function generateIcons (loader, imageFileStream, pathPrefix, query, callback) {
   var publicPath = getPublicPath(loader._compilation);
   favicons(imageFileStream, {
-    path: '',
-    url: '',
-    icons: query.icons,
-    background: query.background,
-    appName: query.appName
+    path: query.path || null,
+    url: query.url || null,
+    icons: query.icons || null,
+    background: query.background || null,
+    appDescription: query.appDescription || null,
+    developerName: query.developerName || null,
+    developerURL: query.developerURL || null,
+    appName: query.title || null,
+    display: query.display || null,
+    orientation: query.orientation || null,
+    start_url: query.start_url || null,
+    version: query.version || null,
+    logging: query.logging || null,
+    online: query.online || null,
+    preferOnline: query.preferOnline || null
   }, function (err, result) {
     if (err) return callback(err);
     var html = result.html.filter(function (entry) {


### PR DESCRIPTION
It would be cool to be able to pass any of the parameters to [Favicons](https://github.com/haydenbleasel/favicons/blob/master/readme.md#usage).
In my case when specifying an option 'prefix' links to favicons in manifest.json and others were incorrect, so I need to pass 'path' parameter.
