### PR TITLE
Make the configuration from HtmlWebpackplugin (options.favicons) work

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,8 +58,8 @@ FaviconsWebpackPlugin.prototype.apply = function (compiler) {
         if (htmlPluginData.plugin.options.favicons !== false) {
           htmlPluginData.html = htmlPluginData.html.replace(
             /(<\/head>)/i, compilationResult.stats.html.join('') + '$&');
-          callback(null, htmlPluginData);
         }
+        callback(null, htmlPluginData);
       });
     });
   }


### PR DESCRIPTION
With this configuration the callback is never called and blocks the build :

new HtmlWebpackPlugin({
            template: file,
            inject: false,
            filename: filename,
            favicons: false
        })