### PR TITLE
Allow specifying what html files to inject to.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ plugins: [
     // Generate a cache file with control hashes and
     // don't rebuild the favicons until those hashes change
     persistentCache: true,
-    // Inject the html into the html-webpack-plugin
+    // Inject the html into the html-webpack-plugin. Accepts glob patterns
+    // to match against. Assets will only be injected on matching files.
     inject: true,
     // favicon background color (see https://github.com/haydenbleasel/favicons#usage)
     background: '#fff',

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var assert = require('assert');
 var _ = require('lodash');
 var fs = require('fs');
 var path = require('path');
+var minimatch = require('minimatch');
 
 function FaviconsWebpackPlugin (options) {
   if (typeof options === 'string') {
@@ -55,10 +56,16 @@ FaviconsWebpackPlugin.prototype.apply = function (compiler) {
   if (self.options.inject) {
     compiler.plugin('compilation', function (compilation) {
       compilation.plugin('html-webpack-plugin-before-html-processing', function (htmlPluginData, callback) {
-        if (htmlPluginData.plugin.options.favicons !== false) {
+        var files = !_.isBoolean(self.options.inject) && _.castArray(self.options.inject);
+        var shouldInject = !files || _.some(files, function (file) {
+          return minimatch(htmlPluginData.outputName, file);
+        });
+
+        if (shouldInject && htmlPluginData.plugin.options.favicons !== false) {
           htmlPluginData.html = htmlPluginData.html.replace(
             /(<\/head>)/i, compilationResult.stats.html.join('') + '$&');
         }
+
         callback(null, htmlPluginData);
       });
     });

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "favicons": "^4.8.3",
     "loader-utils": "^0.2.14",
     "lodash": "^4.11.1",
+    "minimatch": "^3.0.3",
     "webpack": "^1.13.0"
   }
 }

--- a/test/fixtures/expected/generate-html/unmodified.html
+++ b/test/fixtures/expected/generate-html/unmodified.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Webpack App</title>
+  </head>
+  <body>
+  <script type="text/javascript" src="bundle.js"></script></body>
+</html>

--- a/test/index.js
+++ b/test/index.js
@@ -79,12 +79,16 @@ test('should generate a configured JSON file', async t => {
 test('should work together with the html-webpack-plugin', async t => {
   const stats = await webpack(baseWebpackConfig([
     new FaviconsWebpackPlugin({
+      inject: ['!unmodified.html'],
       logo: LOGO_PATH,
       emitStats: true,
       statsFilename: 'iconstats.json',
       persistentCache: false
     }),
-    new HtmlWebpackPlugin()
+    new HtmlWebpackPlugin(),
+    new HtmlWebpackPlugin({
+      filename: 'unmodified.html'
+    })
   ]));
   const outputPath = stats.compilation.compiler.outputPath;
   const expected = path.resolve(__dirname, 'fixtures/expected/generate-html');
@@ -119,4 +123,3 @@ test('should not recompile if there is a cache file', async t => {
   const diffFiles = compareResult.diffSet.filter((diff) => diff.state !== 'equal');
   t.is(diffFiles[0], undefined);
 });
-


### PR DESCRIPTION
This allows creating multiple client distributions with varying favicons. Solves #17 