### PR TITLE
Add option to disable webapp mode

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -22,7 +22,8 @@ module.exports.compileTemplate = function compileTemplate (options, context, com
         icons: options.icons,
         background: options.background,
         persistentCache: options.persistentCache,
-        appName: options.title
+        appName: options.title,
+        disableWebApp: options.disableWebApp
       }) + '!' + options.logo)
   );
 

--- a/lib/favicons.js
+++ b/lib/favicons.js
@@ -60,6 +60,11 @@ function generateIcons (loader, imageFileStream, pathPrefix, query, callback) {
     .map(function (entry) {
       return entry.replace(/(href=[""])/g, '$1' + publicPath + pathPrefix);
     });
+    if (query.disableWebApp) {
+      html = html.filter(function (entry) {
+        return entry.indexOf('mobile-web-app-capable') === -1;
+      });
+    }
     var loaderResult = {
       outputFilePrefix: pathPrefix,
       html: html,


### PR DESCRIPTION
This adds an option to skip the mobile-web-app-capable and apple-mobile-web-app-capable meta tags.

The rationale behind this is that the "webapp" opened by home icons in iOS is actually a stripped-down, buggy version of safari, not the real thing (e.g. try opening a PDF in this thing...)