### PR TITLE
Option to add favicons at the top of the head

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ plugins: [
     persistentCache: true,
     // Inject the html into the html-webpack-plugin
     inject: true,
+    // Inject the html into the html-webpack-plugin at the start of the head
+    injectAtStart: false
     // favicon background color (see https://github.com/haydenbleasel/favicons#usage)
     background: '#fff',
     // favicon app title (see https://github.com/haydenbleasel/favicons#usage)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ plugins: [
     // Inject the html into the html-webpack-plugin
     inject: true,
     // Inject the html into the html-webpack-plugin at the start of the head
-    injectAtStart: false
+    injectAtStart: false,
     // favicon background color (see https://github.com/haydenbleasel/favicons#usage)
     background: '#fff',
     // favicon app title (see https://github.com/haydenbleasel/favicons#usage)

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ function FaviconsWebpackPlugin (options) {
     statsFilename: 'iconstats-[hash].json',
     persistentCache: true,
     inject: true,
+    injectAtStart: false,
     background: '#fff'
   }, options);
   this.options.icons = _.extend({
@@ -56,8 +57,14 @@ FaviconsWebpackPlugin.prototype.apply = function (compiler) {
     compiler.plugin('compilation', function (compilation) {
       compilation.plugin('html-webpack-plugin-before-html-processing', function (htmlPluginData, callback) {
         if (htmlPluginData.plugin.options.favicons !== false) {
-          htmlPluginData.html = htmlPluginData.html.replace(
-            /(<head[^>]*>)/i, '$1' + compilationResult.stats.html.join(''));
+          if (self.options.injectAtStart){
+            htmlPluginData.html = htmlPluginData.html.replace(
+                /(<head[^>]*>)/i, '$1' + compilationResult.stats.html.join(''));
+          }
+          else {
+            htmlPluginData.html = htmlPluginData.html.replace(
+                /(<\/head>)/i, compilationResult.stats.html.join('') + '$&');
+          }
         }
         callback(null, htmlPluginData);
       });

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ FaviconsWebpackPlugin.prototype.apply = function (compiler) {
       compilation.plugin('html-webpack-plugin-before-html-processing', function (htmlPluginData, callback) {
         if (htmlPluginData.plugin.options.favicons !== false) {
           htmlPluginData.html = htmlPluginData.html.replace(
-            /(<\/head>)/i, compilationResult.stats.html.join('') + '$&');
+            /(<head[^>]*>)/i, '$1' + compilationResult.stats.html.join(''));
         }
         callback(null, htmlPluginData);
       });


### PR DESCRIPTION
Chrome has a delay issue. If the favicons aren't loaded within a certain time chrome tries to fetch favicon.ico. We have an analytics script that once in a while takes to long to load and we need the favicons to be the first thing to load in order to avoid that issue.
So i added the option injectAtStart and it it's set to true we append the html otherwise we run the default prepend.