### PR TITLE
Added done event with manifest as argument, for other plugins to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ plugins: [
 ]
 ```
 
+# Events
+
+| name | listener signature | 
+| ---- | ------------------ | 
+| `done` | `function(manifest) {}` |
+
 # Changelog
 
 Take a look at the  [CHANGELOG.md](https://github.com/jantimon/favicons-webpack-plugin/tree/master/CHANGELOG.md).

--- a/README.md
+++ b/README.md
@@ -85,11 +85,47 @@ plugins: [
 ]
 ```
 
-# Events
+Events
+------
 
-| name | listener signature | 
-| ---- | ------------------ | 
-| `done` | `function(manifest) {}` |
+To allow other [plugins](https://github.com/webpack/docs/wiki/plugins) to use 
+the resulting html, this plugin executes the following events:
+
+Async:
+
+  * `favicons-webpack-plugin-after-make`
+
+Usage:
+
+```javascript
+// MyPlugin.js
+
+function MyPlugin(options) {
+  // Configure your plugin with options...
+}
+
+MyPlugin.prototype.apply = function(compiler) {
+  // ...
+  compiler.plugin('compilation', function(compilation) {
+    console.log('The compiler is starting a new compilation...');
+
+    compilation.plugin('favicons-webpack-plugin-after-make', function(pluginData, callback) {
+      console.log('Resulting favicon html: pluginData.html');
+      callback();
+    });
+  });
+
+};
+
+module.exports = MyPlugin;
+```
+Then in `webpack.config.js`
+
+```javascript
+plugins: [
+  new MyPlugin({options: ''})
+]
+```
 
 # Changelog
 

--- a/index.js
+++ b/index.js
@@ -4,8 +4,13 @@ var assert = require('assert');
 var _ = require('lodash');
 var fs = require('fs');
 var path = require('path');
+var util = require('util');
+var EventEmitter = require('events');
 
 function FaviconsWebpackPlugin (options) {
+
+  EventEmitter.call(this);
+
   if (typeof options === 'string') {
     options = {logo: options};
   }
@@ -32,6 +37,8 @@ function FaviconsWebpackPlugin (options) {
     windows: false
   }, this.options.icons);
 }
+
+util.inherits(FaviconsWebpackPlugin, EventEmitter);
 
 FaviconsWebpackPlugin.prototype.apply = function (compiler) {
   var self = this;
@@ -71,6 +78,8 @@ FaviconsWebpackPlugin.prototype.apply = function (compiler) {
       callback();
     });
   }
+
+  compiler.plugin('done', () => this.emit('done', compilationResult && compilationResult.stats));
 };
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -120,3 +120,10 @@ test('should not recompile if there is a cache file', async t => {
   t.is(diffFiles[0], undefined);
 });
 
+test('should emit the done event with the stats', async t => {
+  let doneEventCalledWithManifest = false;
+  const faviconsWebpackPlugin = new FaviconsWebpackPlugin({logo: LOGO_PATH});
+  faviconsWebpackPlugin.on('done', (manifest) => doneEventCalledWithManifest = !!manifest);
+  const stats = await webpack(baseWebpackConfig(faviconsWebpackPlugin));
+  t.is(doneEventCalledWithManifest, true);
+});


### PR DESCRIPTION
 like static-site-generate-webpack-plugin

I needed this for my new fabricator-builder, which is based on webpack with a multiconfig. So basically, the user can use this plugin in his/her toolkit specific config, and the second config is the fabricator-builder config, which can have this plugin instance as an option, and then will wait for the done event to be able to get the favicon html and inject it on the toolkit pages.

I used the assets-manifest plugin to copy this behavior.