### PR TITLE
Manifest.json and Browserconfig.xml

### DIFF
--- a/lib/favicons.js
+++ b/lib/favicons.js
@@ -47,7 +47,7 @@ function getPublicPath (compilation) {
 function generateIcons (loader, imageFileStream, pathPrefix, query, callback) {
   var publicPath = getPublicPath(loader._compilation);
   favicons(imageFileStream, {
-  path: '',
+    path: '',
     url: '',
     icons: query.icons,
     background: query.background,

--- a/lib/favicons.js
+++ b/lib/favicons.js
@@ -47,33 +47,36 @@ function getPublicPath (compilation) {
 function generateIcons (loader, imageFileStream, pathPrefix, query, callback) {
   var publicPath = getPublicPath(loader._compilation);
   favicons(imageFileStream, {
-    path: '',
-    url: '',
-    icons: query.icons,
-    background: query.background,
-    appName: query.appName
-  }, function (err, result) {
-    if (err) return callback(err);
-    var html = result.html.filter(function (entry) {
-      return entry.indexOf('manifest') === -1;
-    })
-    .map(function (entry) {
-      return entry.replace(/(href=[""])/g, '$1' + publicPath + pathPrefix);
-    });
-    var loaderResult = {
-      outputFilePrefix: pathPrefix,
-      html: html,
-      files: []
-    };
-    result.images.forEach(function (image) {
-      loaderResult.files.push(pathPrefix + image.name);
-      loader.emitFile(pathPrefix + image.name, image.contents);
-    });
-    result.files.forEach(function (file) {
-      loaderResult.files.push(pathPrefix + file.name);
-      loader.emitFile(pathPrefix + file.name, file.contents);
-    });
-    callback(null, loaderResult);
+      path: '',
+      url: '',
+      icons: query.icons,
+      background: query.background,
+      appName: query.appName
+    }, function (err, result) {
+      if (err) return callback(err);
+      var html = result.html
+        .map(function (entry) {
+          return entry
+            .replace(/(href=[""])/g, '$1' + publicPath + pathPrefix)
+            .replace(/content="([\w,\s-]+\.[A-Za-z]{3,4})"/g, 'content="'+publicPath + pathPrefix + '$1"');
+        });
+
+      var loaderResult = {
+        outputFilePrefix: pathPrefix,
+        html: html,
+        files: []
+      };
+
+      result.images.forEach(function (image) {
+        loaderResult.files.push(pathPrefix + image.name);
+        loader.emitFile(pathPrefix + image.name, image.contents);
+      });
+
+      result.files.forEach(function (file) {
+        loaderResult.files.push(pathPrefix + file.name);
+        var contents = file.contents.replace(/"([\w,\s-]+\.[A-Za-z]{3,4})"/g, '"' + publicPath + pathPrefix + '$1"');
+        loader.emitFile(pathPrefix + file.name, contents);
+      });
   });
 }
 

--- a/lib/favicons.js
+++ b/lib/favicons.js
@@ -47,38 +47,37 @@ function getPublicPath (compilation) {
 function generateIcons (loader, imageFileStream, pathPrefix, query, callback) {
   var publicPath = getPublicPath(loader._compilation);
   favicons(imageFileStream, {
-      path: '',
-      url: '',
-      icons: query.icons,
-      background: query.background,
-      appName: query.appName
-    }, function (err, result) {
-      if (err) return callback(err);
-      var html = result.html
-        .map(function (entry) {
-          return entry
-            .replace(/(href=[""])/g, '$1' + publicPath + pathPrefix)
-            .replace(/content="([\w,\s-]+\.[A-Za-z]{3,4})"/g, 'content="'+publicPath + pathPrefix + '$1"');
-        });
+  path: '',
+    url: '',
+    icons: query.icons,
+    background: query.background,
+    appName: query.appName
+  }, function (err, result) {
+    if (err) return callback(err);
+    var html = result.html.map(function (entry) {
+      return entry
+        .replace(/(href=[""])/g, '$1' + publicPath + pathPrefix)
+        .replace(/content="([\w,\s-]+\.[A-Za-z]{3,4})"/g, 'content="'+publicPath + pathPrefix + '$1"');
+    });
 
-      var loaderResult = {
-        outputFilePrefix: pathPrefix,
-        html: html,
-        files: []
-      };
+    var loaderResult = {
+      outputFilePrefix: pathPrefix,
+      html: html,
+      files: []
+    };
 
-      result.images.forEach(function (image) {
-        loaderResult.files.push(pathPrefix + image.name);
-        loader.emitFile(pathPrefix + image.name, image.contents);
-      });
+    result.images.forEach(function (image) {
+      loaderResult.files.push(pathPrefix + image.name);
+      loader.emitFile(pathPrefix + image.name, image.contents);
+    });
 
-      result.files.forEach(function (file) {
-        loaderResult.files.push(pathPrefix + file.name);
-        var contents = file.contents.replace(/"([\w,\s-]+\.[A-Za-z]{3,4})"/g, '"' + publicPath + pathPrefix + '$1"');
-        loader.emitFile(pathPrefix + file.name, contents);
-      });
+    result.files.forEach(function (file) {
+      loaderResult.files.push(pathPrefix + file.name);
+      var contents = file.contents.replace(/"([\w,\s-]+\.[A-Za-z]{3,4})"/g, '"' + publicPath + pathPrefix + '$1"');
+      loader.emitFile(pathPrefix + file.name, contents);
+    });
     
-      callback(null, loaderResult);
+    callback(null, loaderResult);
   });
 }
 

--- a/lib/favicons.js
+++ b/lib/favicons.js
@@ -77,6 +77,8 @@ function generateIcons (loader, imageFileStream, pathPrefix, query, callback) {
         var contents = file.contents.replace(/"([\w,\s-]+\.[A-Za-z]{3,4})"/g, '"' + publicPath + pathPrefix + '$1"');
         loader.emitFile(pathPrefix + file.name, contents);
       });
+    
+      callback(null, loaderResult);
   });
 }
 


### PR DESCRIPTION
Improvements to facilitiate Android and Windows support more fully

 - [x] Remove filter for `manifest.json`
 - [x] Rewrite HTML entries matching pattern `content="[somefilename.ext]"` to insert corrected paths
 - [x] Rewrite `file.contents` to insert correct paths into any files listed therein.

Notes:
1. Would be much better not to be using regexes here - better to parse properly, but is too big a change for this PR
2. Searching for any filename at all in `file.contents` probably isn't appropriate long-term. A better approach would be to create specific handlers for each device/output type and handle accordingly, but who has time? :smile: