### PR TITLE
pass `theme_color` to `favicons`

### DIFF
--- a/lib/favicons.js
+++ b/lib/favicons.js
@@ -51,6 +51,7 @@ function generateIcons (loader, imageFileStream, pathPrefix, query, callback) {
     url: '',
     icons: query.icons,
     background: query.background,
+    theme_color: query.theme_color,
     appName: query.appName
   }, function (err, result) {
     if (err) return callback(err);


### PR DESCRIPTION
allows us to use the `theme_color` property, which will result in changing the theme-color meta tag.