### PR TITLE
Move webpack to peerDependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /dist/
 /example/dist/
 npm-debug.log
+yarn.lock

--- a/package.json
+++ b/package.json
@@ -50,7 +50,9 @@
   "dependencies": {
     "favicons": "^4.8.3",
     "loader-utils": "^0.2.14",
-    "lodash": "^4.11.1",
-    "webpack": "^1.13.0"
+    "lodash": "^4.11.1"
+  },
+  "peerDependencies": {
+    "webpack": "^1.13.0 || ^2.0.0 || ^3.0.0"
   }
 }


### PR DESCRIPTION
This is the only project in my app dependencies that has webpack as a dependency and not a peerDependency, any it breaks my karma test suite. This change moves webpack into peerDependencies and allows the use of newer versions of webpack (v2 and v3).