### PR TITLE
Remove default for empty prefix

### DIFF
--- a/lib/favicons.js
+++ b/lib/favicons.js
@@ -11,11 +11,12 @@ module.exports = function (content) {
 
   var callback = self.async();
   var query = loaderUtils.parseQuery(self.query);
-  var pathPrefix = loaderUtils.interpolateName(self, query.outputFilePrefix, {
-    context: query.context || this.options.context,
-    content: content,
-    regExp: query.regExp
-  });
+  var pathPrefix = query.outputFilePrefix !== '' ?
+    loaderUtils.interpolateName(self, query.outputFilePrefix, {
+      context: query.context || this.options.context,
+      content: content,
+      regExp: query.regExp
+    }) : '';
   var fileHash = loaderUtils.interpolateName(self, '[hash]', {
     context: query.context || this.options.context,
     content: content,


### PR DESCRIPTION
An empty prefix setting (i.e.: install all icons into the document root)
was treated by loaderUtils.interpolateName() as '[hash].[ext]'.

While this may be a useful default in other contexts, it is wrong here
where a directory template gets interpolated. So handle the empty string
specially.