### PR TITLE
Added compatibility for new Webpack 4 .hooks mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,8 +51,7 @@ FaviconsWebpackPlugin.prototype.apply = function (compiler) {
         callback();
       })
       .catch(callback);
-    }
-  );
+  });
 
   // Hook into the html-webpack-plugin processing
   // and add the html

--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ FaviconsWebpackPlugin.prototype.apply = function (compiler) {
   // Remove the stats from the output if they are not required
   if (!self.options.emitStats) {
     if (compiler.hooks) {
-      compiler.hooks.emit.tapAsync("FaviconsWebpackPluginEmit", (compilation, callback) => {
+      compiler.hooks.emit.tapAsync('FaviconsWebpackPluginEmit', (compilation, callback) => {
         delete compilation.assets[compilationResult.outputName];
         callback();
       });

--- a/index.js
+++ b/index.js
@@ -41,17 +41,18 @@ FaviconsWebpackPlugin.prototype.apply = function (compiler) {
 
   // Generate the favicons (webpack 4 compliant + back compat)
   var compilationResult;
-  (compiler.hooks ?
-    compiler.hooks.make.tapAsync.bind(compiler.hooks.make, 'FaviconsWebpackPluginMake') :
-    compiler.plugin.bind(compiler, 'make')
+  (compiler.hooks
+    ? compiler.hooks.make.tapAsync.bind(compiler.hooks.make, 'FaviconsWebpackPluginMake')
+    : compiler.plugin.bind(compiler, 'make')
   )((compilation, callback) => {
-      childCompiler.compileTemplate(self.options, compiler.context, compilation)
-        .then(function (result) {
-          compilationResult = result;
-          callback();
-        })
-        .catch(callback);
-    });
+    childCompiler.compileTemplate(self.options, compiler.context, compilation)
+      .then(function (result) {
+        compilationResult = result;
+        callback();
+      })
+      .catch(callback);
+    }
+  );
 
   // Hook into the html-webpack-plugin processing
   // and add the html
@@ -86,9 +87,9 @@ FaviconsWebpackPlugin.prototype.apply = function (compiler) {
 
   // Remove the stats from the output if they are not required (webpack 4 compliant + back compat)
   if (!self.options.emitStats) {
-    (compiler.hooks ?
-      compiler.hooks.emit.tapAsync.bind(compiler.hooks.emit, 'FaviconsWebpackPluginEmit') :
-      compiler.plugin.bind(compiler, 'emit')
+    (compiler.hooks
+      ? compiler.hooks.emit.tapAsync.bind(compiler.hooks.emit, 'FaviconsWebpackPluginEmit')
+      : compiler.plugin.bind(compiler, 'emit')
     )((compilation, callback) => {
       delete compilation.assets[compilationResult.outputName];
       callback();

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -16,98 +16,59 @@ module.exports.compileTemplate = function compileTemplate (options, context, com
   var childCompiler = compilation.createChildCompiler(compilerName, outputOptions);
   childCompiler.context = context;
 
-  if (compilation.hooks) {
-    new SingleEntryPlugin(context, '!!' + require.resolve('./favicons.js') + '?' +
-        JSON.stringify({
-          outputFilePrefix: options.prefix,
-          icons: options.icons,
-          background: options.background,
-          persistentCache: options.persistentCache,
-          appName: options.title
-        }) + '!' + options.logo).apply(childCompiler);
-  } else {
-    childCompiler.apply(
-      new SingleEntryPlugin(context, '!!' + require.resolve('./favicons.js') + '?' +
-        JSON.stringify({
-          outputFilePrefix: options.prefix,
-          icons: options.icons,
-          background: options.background,
-          persistentCache: options.persistentCache,
-          appName: options.title
-        }) + '!' + options.logo)
-    );
-  }
+  var singleEntryPlugin = new SingleEntryPlugin(context, '!!' + require.resolve('./favicons.js') + '?' +
+    JSON.stringify({
+      outputFilePrefix: options.prefix,
+      icons: options.icons,
+      background: options.background,
+      persistentCache: options.persistentCache,
+      appName: options.title
+    }) + '!' + options.logo);
+
+  (compilation.hooks ? singleEntryPlugin.apply(childCompiler) : childCompiler.apply(singleEntryPlugin));
 
   // Fix for "Uncaught TypeError: __webpack_require__(...) is not a function"
   // Hot module replacement requires that every child compiler has its own
   // cache. @see https://github.com/ampedandwired/html-webpack-plugin/pull/179
-  if (compilation.hooks) {
-    childCompiler.hooks.compilation.tap('FaviconsWebpackPluginCompilation', (compilation) => {
-      if (compilation.cache) {
-        if (!compilation.cache[compilerName]) {
-          compilation.cache[compilerName] = {};
-        }
-        compilation.cache = compilation.cache[compilerName];
+  // (webpack 4 compliant + back compat)
+  (childCompiler.hooks ?
+    childCompiler.hooks.compilation.tap.bind(childCompiler.hooks.compilation, 'FaviconsWebpackPluginCompilation') :
+    childCompiler.plugin.bind(childCompiler, 'compilation')
+  )((compilation) => {
+    if (compilation.cache) {
+      if (!compilation.cache[compilerName]) {
+        compilation.cache[compilerName] = {};
       }
-      compilation.hooks.optimizeChunkAssets.tapAsync('FaviconsWebpackPluginOptimizeChunkAssets', (chunks, callback) => {
-        if (!chunks[0]) {
-          return callback(compilation.errors[0] || 'Favicons generation failed');
-        }
-        var resultFile = chunks[0].files[0];
-        var resultCode = compilation.assets[resultFile].source();
-        var resultJson;
-        try {
-          /* eslint no-eval:0 */
-          var result = eval(resultCode);
-          resultJson = JSON.stringify(result);
-        } catch (e) {
-          return callback(e);
-        }
-        compilation.assets[resultFile] = {
-          source: function () {
-            return resultJson;
-          },
-          size: function () {
-            return resultJson.length;
-          }
-        };
-        callback(null);
-      });
-    });
-  } else {
-    childCompiler.plugin('compilation', function (compilation) {
-      if (compilation.cache) {
-        if (!compilation.cache[compilerName]) {
-          compilation.cache[compilerName] = {};
-        }
-        compilation.cache = compilation.cache[compilerName];
+      compilation.cache = compilation.cache[compilerName];
+    }
+    (compilation.hooks ?
+      compilation.hooks.optimizeChunkAssets.tapAsync.bind(compilation.hooks.optimizeChunkAssets, 'FaviconsWebpackPluginOptimizeChunkAssets') :
+      compilation.plugin.bind(compilation, 'optimize-chunk-assets')
+    )((chunks, callback) => {
+      if (!chunks[0]) {
+        return callback(compilation.errors[0] || 'Favicons generation failed');
       }
-      compilation.plugin('optimize-chunk-assets', function (chunks, callback) {
-        if (!chunks[0]) {
-          return callback(compilation.errors[0] || 'Favicons generation failed');
+      var resultFile = chunks[0].files[0];
+      var resultCode = compilation.assets[resultFile].source();
+      var resultJson;
+      try {
+        /* eslint no-eval:0 */
+        var result = eval(resultCode);
+        resultJson = JSON.stringify(result);
+      } catch (e) {
+        return callback(e);
+      }
+      compilation.assets[resultFile] = {
+        source: function () {
+          return resultJson;
+        },
+        size: function () {
+          return resultJson.length;
         }
-        var resultFile = chunks[0].files[0];
-        var resultCode = compilation.assets[resultFile].source();
-        var resultJson;
-        try {
-          /* eslint no-eval:0 */
-          var result = eval(resultCode);
-          resultJson = JSON.stringify(result);
-        } catch (e) {
-          return callback(e);
-        }
-        compilation.assets[resultFile] = {
-          source: function () {
-            return resultJson;
-          },
-          size: function () {
-            return resultJson.length;
-          }
-        };
-        callback(null);
-      });
+      };
+      callback(null);
     });
-  }
+  });
 
   // Compile and return a promise
   return new Promise(function (resolve, reject) {

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -42,7 +42,7 @@ module.exports.compileTemplate = function compileTemplate (options, context, com
   // Hot module replacement requires that every child compiler has its own
   // cache. @see https://github.com/ampedandwired/html-webpack-plugin/pull/179
   if (compilation.hooks) {
-    childCompiler.hooks.compilation.tap("FaviconsWebpackPluginCompilation", (compilation) => {
+    childCompiler.hooks.compilation.tap('FaviconsWebpackPluginCompilation', (compilation) => {
       if (compilation.cache) {
         if (!compilation.cache[compilerName]) {
           compilation.cache[compilerName] = {};

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -15,52 +15,99 @@ module.exports.compileTemplate = function compileTemplate (options, context, com
   var compilerName = getCompilerName(context, outputOptions.filename);
   var childCompiler = compilation.createChildCompiler(compilerName, outputOptions);
   childCompiler.context = context;
-  childCompiler.apply(
+
+  if (compilation.hooks) {
     new SingleEntryPlugin(context, '!!' + require.resolve('./favicons.js') + '?' +
-      JSON.stringify({
-        outputFilePrefix: options.prefix,
-        icons: options.icons,
-        background: options.background,
-        persistentCache: options.persistentCache,
-        appName: options.title
-      }) + '!' + options.logo)
-  );
+        JSON.stringify({
+          outputFilePrefix: options.prefix,
+          icons: options.icons,
+          background: options.background,
+          persistentCache: options.persistentCache,
+          appName: options.title
+        }) + '!' + options.logo).apply(childCompiler);
+  } else {
+    childCompiler.apply(
+      new SingleEntryPlugin(context, '!!' + require.resolve('./favicons.js') + '?' +
+        JSON.stringify({
+          outputFilePrefix: options.prefix,
+          icons: options.icons,
+          background: options.background,
+          persistentCache: options.persistentCache,
+          appName: options.title
+        }) + '!' + options.logo)
+    );
+  }
 
   // Fix for "Uncaught TypeError: __webpack_require__(...) is not a function"
   // Hot module replacement requires that every child compiler has its own
   // cache. @see https://github.com/ampedandwired/html-webpack-plugin/pull/179
-  childCompiler.plugin('compilation', function (compilation) {
-    if (compilation.cache) {
-      if (!compilation.cache[compilerName]) {
-        compilation.cache[compilerName] = {};
-      }
-      compilation.cache = compilation.cache[compilerName];
-    }
-    compilation.plugin('optimize-chunk-assets', function (chunks, callback) {
-      if (!chunks[0]) {
-        return callback(compilation.errors[0] || 'Favicons generation failed');
-      }
-      var resultFile = chunks[0].files[0];
-      var resultCode = compilation.assets[resultFile].source();
-      var resultJson;
-      try {
-        /* eslint no-eval:0 */
-        var result = eval(resultCode);
-        resultJson = JSON.stringify(result);
-      } catch (e) {
-        return callback(e);
-      }
-      compilation.assets[resultFile] = {
-        source: function () {
-          return resultJson;
-        },
-        size: function () {
-          return resultJson.length;
+  if (compilation.hooks) {
+    childCompiler.hooks.compilation.tap("FaviconsWebpackPluginCompilation", (compilation) => {
+      if (compilation.cache) {
+        if (!compilation.cache[compilerName]) {
+          compilation.cache[compilerName] = {};
         }
-      };
-      callback(null);
+        compilation.cache = compilation.cache[compilerName];
+      }
+      compilation.hooks.optimizeChunkAssets.tapAsync('FaviconsWebpackPluginOptimizeChunkAssets', (chunks, callback) => {
+        if (!chunks[0]) {
+          return callback(compilation.errors[0] || 'Favicons generation failed');
+        }
+        var resultFile = chunks[0].files[0];
+        var resultCode = compilation.assets[resultFile].source();
+        var resultJson;
+        try {
+          /* eslint no-eval:0 */
+          var result = eval(resultCode);
+          resultJson = JSON.stringify(result);
+        } catch (e) {
+          return callback(e);
+        }
+        compilation.assets[resultFile] = {
+          source: function () {
+            return resultJson;
+          },
+          size: function () {
+            return resultJson.length;
+          }
+        };
+        callback(null);
+      });
     });
-  });
+  } else {
+    childCompiler.plugin('compilation', function (compilation) {
+      if (compilation.cache) {
+        if (!compilation.cache[compilerName]) {
+          compilation.cache[compilerName] = {};
+        }
+        compilation.cache = compilation.cache[compilerName];
+      }
+      compilation.plugin('optimize-chunk-assets', function (chunks, callback) {
+        if (!chunks[0]) {
+          return callback(compilation.errors[0] || 'Favicons generation failed');
+        }
+        var resultFile = chunks[0].files[0];
+        var resultCode = compilation.assets[resultFile].source();
+        var resultJson;
+        try {
+          /* eslint no-eval:0 */
+          var result = eval(resultCode);
+          resultJson = JSON.stringify(result);
+        } catch (e) {
+          return callback(e);
+        }
+        compilation.assets[resultFile] = {
+          source: function () {
+            return resultJson;
+          },
+          size: function () {
+            return resultJson.length;
+          }
+        };
+        callback(null);
+      });
+    });
+  }
 
   // Compile and return a promise
   return new Promise(function (resolve, reject) {

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -31,9 +31,9 @@ module.exports.compileTemplate = function compileTemplate (options, context, com
   // Hot module replacement requires that every child compiler has its own
   // cache. @see https://github.com/ampedandwired/html-webpack-plugin/pull/179
   // (webpack 4 compliant + back compat)
-  (childCompiler.hooks ?
-    childCompiler.hooks.compilation.tap.bind(childCompiler.hooks.compilation, 'FaviconsWebpackPluginCompilation') :
-    childCompiler.plugin.bind(childCompiler, 'compilation')
+  (childCompiler.hooks
+    ? childCompiler.hooks.compilation.tap.bind(childCompiler.hooks.compilation, 'FaviconsWebpackPluginCompilation')
+    : childCompiler.plugin.bind(childCompiler, 'compilation')
   )((compilation) => {
     if (compilation.cache) {
       if (!compilation.cache[compilerName]) {
@@ -41,9 +41,9 @@ module.exports.compileTemplate = function compileTemplate (options, context, com
       }
       compilation.cache = compilation.cache[compilerName];
     }
-    (compilation.hooks ?
-      compilation.hooks.optimizeChunkAssets.tapAsync.bind(compilation.hooks.optimizeChunkAssets, 'FaviconsWebpackPluginOptimizeChunkAssets') :
-      compilation.plugin.bind(compilation, 'optimize-chunk-assets')
+    (compilation.hooks
+      ? compilation.hooks.optimizeChunkAssets.tapAsync.bind(compilation.hooks.optimizeChunkAssets, 'FaviconsWebpackPluginOptimizeChunkAssets')
+      : compilation.plugin.bind(compilation, 'optimize-chunk-assets')
     )((chunks, callback) => {
       if (!chunks[0]) {
         return callback(compilation.errors[0] || 'Favicons generation failed');


### PR DESCRIPTION
As per issue #112, I've updated all references to `compiler.plugin` and `compiler.apply` with the new `.hooks` syntax as documented [in this article](https://blog.johnnyreilly.com/2018/01/finding-webpack-4-use-map.html). Backwards compatibility is maintained.