### PR TITLE
Fix reference to browserconfig.xml

### DIFF
--- a/lib/favicons.js
+++ b/lib/favicons.js
@@ -59,8 +59,8 @@ function generateIcons (loader, imageFileStream, pathPrefix, query, callback) {
     })
     .map(function (entry) {
       let rewritten = entry.replace(/(href=[""])/g, '$1' + publicPath + pathPrefix);
-      if (rewritten.indexOf('msapplication') !== -1) {
-        return rewritten.replace(/(content=[""])/g, '$' + publicPath + pathPrefix);
+      if (rewritten.indexOf('msapplication-config') !== -1) {
+        return rewritten.replace(/(content=[""])/g, '$1' + publicPath + pathPrefix);
       }
       return rewritten;
     });

--- a/lib/favicons.js
+++ b/lib/favicons.js
@@ -59,7 +59,8 @@ function generateIcons (loader, imageFileStream, pathPrefix, query, callback) {
     })
     .map(function (entry) {
       let rewritten = entry.replace(/(href=[""])/g, '$1' + publicPath + pathPrefix);
-      if (rewritten.indexOf('msapplication-config') !== -1) {
+      if (rewritten.indexOf('msapplication-config') !== -1 ||
+          rewritten.indexOf('msapplication-TileImage') !== -1) {
         return rewritten.replace(/(content=[""])/g, '$1' + publicPath + pathPrefix);
       }
       return rewritten;

--- a/lib/favicons.js
+++ b/lib/favicons.js
@@ -58,7 +58,11 @@ function generateIcons (loader, imageFileStream, pathPrefix, query, callback) {
       return entry.indexOf('manifest') === -1;
     })
     .map(function (entry) {
-      return entry.replace(/(href=[""])/g, '$1' + publicPath + pathPrefix);
+      let rewritten = entry.replace(/(href=[""])/g, '$1' + publicPath + pathPrefix);
+      if (rewritten.indexOf('msapplication') !== -1) {
+        return rewritten.replace(/(content=[""])/g, '$' + publicPath + pathPrefix);
+      }
+      return rewritten;
     });
     var loaderResult = {
       outputFilePrefix: pathPrefix,


### PR DESCRIPTION
This small patch fixes an issue with `browserconfig.xml`, linked-to by `<meta name="msapplication-config" ...>`. Currently, because it uses the `content` attribute to reference its path, it isn't rewritten to respect `prefix` and `publicPath` as-configured in the `favicons-webpack-plugin` module.

This changeset applies the same `href=` rewrites on the icons, to the `browserconfig.xml` - but only for tags containing `msapplication`, to avoid breaking any other behavior.

Fixes and closes #114.