### PR TITLE
Make plugin work without html-webpack-plugin (webpack 4)

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ FaviconsWebpackPlugin.prototype.apply = function (compiler) {
       compiler.hooks.compilation.tap('FaviconsWebpackPlugin', function (cmpp) {
         compiler.hooks.compilation.tap('HtmlWebpackPluginHooks', function () {
           if (!tapped++) {
-            cmpp.hooks.htmlWebpackPluginBeforeHtmlProcessing.tapAsync(
+            cmpp.hooks.htmlWebpackPluginBeforeHtmlProcessing && cmpp.hooks.htmlWebpackPluginBeforeHtmlProcessing.tapAsync(
               'favicons-webpack-plugin',
               addFaviconsToHtml
             );


### PR DESCRIPTION
This simply checks if cmpp.hooks.htmlWebpackPluginBeforeHtmlProcessing exists before tapping.
Fixes #130 for me. Hope that it makes sense generally.

Cheers! <3

(done directly in github)