### PR TITLE
hook compilation rather than compiler

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,8 +33,6 @@ function FaviconsWebpackPlugin (options) {
   }, this.options.icons);
 }
 
-var tapped = 0;
-
 FaviconsWebpackPlugin.prototype.apply = function (compiler) {
   var self = this;
   if (!self.options.title) {
@@ -69,14 +67,7 @@ FaviconsWebpackPlugin.prototype.apply = function (compiler) {
     // webpack 4
     if (compiler.hooks) {
       compiler.hooks.compilation.tap('FaviconsWebpackPlugin', function (cmpp) {
-        compiler.hooks.compilation.tap('HtmlWebpackPluginHooks', function () {
-          if (!tapped++) {
-            cmpp.hooks.htmlWebpackPluginBeforeHtmlProcessing.tapAsync(
-              'favicons-webpack-plugin',
-              addFaviconsToHtml
-            );
-          }
-        });
+        cmpp.hooks.htmlWebpackPluginBeforeHtmlProcessing.tapAsync('favicons-webpack-plugin', addFaviconsToHtml);
       });
     } else {
       compiler.plugin('compilation', function (compilation) {


### PR DESCRIPTION
## Issue
maybe related: https://github.com/jantimon/favicons-webpack-plugin/issues/118

## The problem PR solves
The original code could be simplified as:

```
compiler.hooks.compilation.tap((cmpp) => {
  compiler.hooks.compilation.tap(() => {
    cmpp.hooks.html.tap(...)
  })
})
```

So every time a compilation is fired, the compiler will get installed w/ a new hook, which keeps memory usage increasing rapidly. The issue is noticeable especially under HMR.

## By how
I deleted the compiler hook part. If I missed anything, please let me know :)