### PR TITLE
Adding support for extra manifest.json properties from the options object

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,17 @@ plugins: [
       icons: {
         coast: false,
         yandex: false
-      }
+      },
+      appConfig: { // extra manifest properties not supported by favicons module
+        prefer_related_applications: true,
+        related_applications: [
+          {
+            platform: 'play',
+            id: 'com.google.samples.apps.iosched',
+          },
+          lang: "en-US",
+        ],
+      },
     }
   })
 ]

--- a/src/loader.js
+++ b/src/loader.js
@@ -26,19 +26,24 @@ module.exports = async function(content) {
     content,
     Object.assign(query.options, { path: url.resolve(path, prefix) })
   );
-  
-  // We enrich the manifest.json with custom values from options.appConfig 
+
+  // We enrich the manifest.json with custom values from options.appConfig
   // if they are not supported in the favicons plugin
   if (query.options.appConfig) {
-    const mainfestIndex = files.findIndex(({ name }) => name === 'manifest.json');
+    const mainfestIndex = files.findIndex(
+      ({ name }) => name === 'manifest.json'
+    );
     const manifestContent = JSON.parse(files[mainfestIndex].contents);
-    const newContent = Buffer.from(JSON.stringify(
-      { ...manifestContent, ...query.options.appConfig },
-      null, 4
-    ));
-   files[mainfestIndex].contents = newContent;
+    const newContent = Buffer.from(
+      JSON.stringify(
+        { ...manifestContent, ...query.options.appConfig },
+        null,
+        4
+      )
+    );
+    files[mainfestIndex].contents = newContent;
   }
-  
+
   const assets = [...images, ...files].map(({ name, contents }) => ({
     name: outputPath + name,
     contents: toBase64(contents)

--- a/src/loader.js
+++ b/src/loader.js
@@ -26,6 +26,19 @@ module.exports = async function(content) {
     content,
     Object.assign(query.options, { path: url.resolve(path, prefix) })
   );
+  
+  // We enrich the manifest.json with custom values from options.appConfig 
+  // if they are not supported in the favicons plugin
+  if (query.options.appConfig) {
+    const mainfestIndex = files.findIndex(({ name }) => name === 'manifest.json');
+    const manifestContent = JSON.parse(files[mainfestIndex].contents);
+    const newContent = Buffer.from(JSON.stringify(
+      { ...manifestContent, ...query.options.appConfig },
+      null, 4
+    ));
+   files[mainfestIndex].contents = newContent;
+  }
+  
   const assets = [...images, ...files].map(({ name, contents }) => ({
     name: outputPath + name,
     contents: toBase64(contents)


### PR DESCRIPTION
This PR enables insertion of  extra properties in the manifest.json that are not supported via the `favicons` module. 
It is done to be minimally intrusive with low possibility of conflicts with other manifest.json fields.