### PR TITLE
fix: use @types/favicons@6.2.1 to match favicons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -818,9 +818,9 @@
       "dev": true
     },
     "@types/favicons": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@types/favicons/-/favicons-6.2.0.tgz",
-      "integrity": "sha512-GUzr3u7iwyP6MBCVRaXiNCTYV1FZMQ8kSTDFToXNasmVfn2THi5QVCP42p98m7uYiCrxb974cgXnadL3/ZxUig==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@types/favicons/-/favicons-6.2.1.tgz",
+      "integrity": "sha512-7mSNayh1MI42vgKX24BDjHnbMyAeHdaDCos4PZLdQC9pKrY1/Q0AiDqi5pETR82mEYWcjNZA9W3xK2yxeXrXxA==",
       "requires": {
         "@types/node": "*"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -818,9 +818,9 @@
       "dev": true
     },
     "@types/favicons": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@types/favicons/-/favicons-5.5.0.tgz",
-      "integrity": "sha512-s76OlRaBfqtGu2ZBobnZv2NETfqsQUVfKKlOkKNGo4ArBsqiblodKsnQ3j29hCCgmpQacEfLxealV96za+tzVQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@types/favicons/-/favicons-6.2.0.tgz",
+      "integrity": "sha512-GUzr3u7iwyP6MBCVRaXiNCTYV1FZMQ8kSTDFToXNasmVfn2THi5QVCP42p98m7uYiCrxb974cgXnadL3/ZxUig==",
       "requires": {
         "@types/node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "webpack-merge": "^4.2.2"
   },
   "dependencies": {
-    "@types/favicons": "5.5.0",
+    "@types/favicons": "6.2.0",
     "find-root": "^1.1.0",
     "parse-author": "^2.0.0",
     "parse5": "^6.0.1"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "webpack-merge": "^4.2.2"
   },
   "dependencies": {
-    "@types/favicons": "6.2.0",
+    "@types/favicons": "6.2.1",
     "find-root": "^1.1.0",
     "parse-author": "^2.0.0",
     "parse5": "^6.0.1"


### PR DESCRIPTION
This should typecheck:

```ts
new FaviconsWebpackPlugin({
  favicons: {
    icons: {
      android: [
        "android-chrome-192x192.png",
        "android-chrome-512x512.png",
      ],
    },
  },
})
```

But it is currently a type error:

> Type 'string[]' is not assignable to type 'boolean | IconOptions'.

`@types/favicons@6.2.0` has the same issue, so `6.2.1` is necessary.